### PR TITLE
Add urllib3 dep and username/password auth

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ elasticsearch>=8.0.0
 faker>=15.0.0
 tqdm>=4.64.0
 python-dotenv>=0.19.0
+urllib3>=1.26.0
 
 # Interactive control script dependencies
 rich>=13.0.0

--- a/scripts/common_utils.py
+++ b/scripts/common_utils.py
@@ -199,12 +199,21 @@ def create_elasticsearch_client() -> Elasticsearch:
         ValueError: If connection fails
     """
     try:
-        es_client = Elasticsearch(
-            ES_CONFIG['endpoint_url'],
-            api_key=ES_CONFIG['api_key'],
-            request_timeout=ES_CONFIG['request_timeout'],
-            verify_certs=ES_CONFIG['verify_certs']
-        )
+        es_kwargs = {
+            "hosts": [ES_CONFIG['endpoint_url']],
+            "request_timeout": ES_CONFIG['request_timeout'],
+            "verify_certs": ES_CONFIG['verify_certs']
+        }
+
+        if ES_CONFIG.get('api_key'):
+            es_kwargs['api_key'] = ES_CONFIG['api_key']
+        elif ES_CONFIG.get('username') and ES_CONFIG.get('password'):
+            es_kwargs['basic_auth'] = (
+                ES_CONFIG['username'],
+                ES_CONFIG['password']
+            )
+        
+        es_client = Elasticsearch(**es_kwargs)
         
         # Test connection
         if not es_client.info():
@@ -214,7 +223,8 @@ def create_elasticsearch_client() -> Elasticsearch:
         return es_client
         
     except Exception as e:
-        print(f"ERROR: Could not connect to Elasticsearch. Please check your Endpoint URL and API Key. Error: {e}")
+        print("ERROR: Could not connect to Elasticsearch. Please check your Endpoint URL and credentials."
+              f" Error: {e}")
         raise
 
 def _read_and_chunk_from_file(filepath: str, index_name: str, id_key_in_doc: str, batch_size: int,

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -18,6 +18,8 @@ load_dotenv()
 ES_CONFIG = {
     'endpoint_url': os.getenv("ES_ENDPOINT_URL", "https://localhost:9200"),
     'api_key': os.getenv("ES_API_KEY"),
+    'username': os.getenv("ES_USERNAME"),
+    'password': os.getenv("ES_PASSWORD"),
     'bulk_batch_size': 100,
     'request_timeout': 60,
     'verify_certs': False,


### PR DESCRIPTION
I ran into some problems trying to run this. 

**Missing urllib3 dependency**
Initially I couldn't run because `urllib3` is missing:

```
Traceback (most recent call last):
  File "/Users/sorenlouv/elastic/synthetic-financial-data/load_all_data.py", line 26, in <module>
    from common_utils import create_elasticsearch_client, ingest_data_to_es
  File "/Users/sorenlouv/elastic/synthetic-financial-data/scripts/common_utils.py", line 20, in <module>
    from urllib3.exceptions import InsecureRequestWarning
ModuleNotFoundError: No module named 'urllib3'
```

**Support for username/password auth**
Afaict this required an API key. For local development it's easier to use the default credentials. Adding support for username/password auth allows for loading data like:

```
ES_ENDPOINT_URL=http://localhost:9200 ES_USERNAME=elastic ES_PASSWORD=changeme python3 load_all_data.py
```